### PR TITLE
os support for AlmaLinux & RockyLinux

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -55,12 +55,14 @@
         "8"
       ]
     },
+    {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
         "8",
         "9"
       ]
     },
+    {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",

--- a/metadata.json
+++ b/metadata.json
@@ -55,6 +55,18 @@
         "8"
       ]
     },
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [


### PR DESCRIPTION
this change in the metadata.json adds support for AlmaLinux and RockyLinux.

it was tested by me and works fine.